### PR TITLE
feat: scaffold landing site and cms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Node
+node_modules/
+.npm/
+.pnpm-store/
+.yarn/
+.next/
+.out/
+dist/
+.env
+.env.*
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Strapi
+cms/.cache/
+cms/build/
+cms/public/uploads/
+
+# Editor
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# thcs-xuancao-landing-page
+# THCS Xuân Cao Website
+
+Triển khai dự án Website giới thiệu và cổng thông tin chính thức cho Trường THCS Xuân Cao bao gồm hai phần chính:
+
+- **frontend/** – Ứng dụng Next.js 14 (App Router) dựng UI, SEO, sitemap và kết nối Strapi qua REST.
+- **cms/** – Cấu hình Strapi v5 với mô hình nội dung, component và các biến môi trường khuyến nghị.
+
+## Cấu trúc
+
+```
+frontend/            # Next.js 14 + Tailwind (App Router)
+  src/
+    app/(public)/    # Các trang SSG/ISR theo sitemap đã thống nhất
+    components/      # Hero, Card, Gallery, Testimonials, PageHeader, ...
+    lib/             # api.ts, seo.ts, utils.ts, image.ts
+    styles/          # Tailwind globals
+  .env.example       # Biến môi trường cho FE
+cms/                 # Strapi v5 schema, config
+  src/api/           # Content types (Post, Event, Teacher, ...)
+  src/components/    # Component Seo, CTA, StatItem, ...
+  .env.example       # Biến môi trường Strapi
+```
+
+## Thiết lập nhanh
+
+### Frontend
+
+1. Cài đặt dependency (yarn/pnpm tùy chọn):
+   ```bash
+   cd frontend
+   pnpm install # hoặc npm install / yarn install
+   ```
+2. Cấu hình `.env.local` dựa trên `.env.example`.
+3. Khởi chạy dev:
+   ```bash
+   pnpm dev
+   ```
+
+Ứng dụng sử dụng SSG + ISR mặc định. Khi chưa có CMS, `lib/api.ts` trả về dữ liệu mock giúp phát triển UI.
+
+### Strapi CMS
+
+1. Cài đặt dependency:
+   ```bash
+   cd cms
+   pnpm install # hoặc npm install / yarn install
+   ```
+2. Tạo file `.env` theo `.env.example`.
+3. Chạy Strapi:
+   ```bash
+   pnpm develop
+   ```
+
+Strapi đã khai báo đầy đủ collection types, single types, component SEO/CTA/... theo kế hoạch. Kích hoạt CORS cho domain Next.js và tạo API Token readonly cho FE.
+
+## Kiểm tra & SEO
+
+- Sitemap động tại `/sitemap.xml`, robots tại `/robots.txt`.
+- `seo.ts` hỗ trợ JSON-LD (Article, Event, Breadcrumb, Organization).
+- Các trang list/detail đều chèn breadcrumbs, meta canonical và dữ liệu cấu trúc.
+
+## Tiếp theo
+
+- Kết nối Cloudinary bằng cách khai báo `CLOUDINARY_URL`, `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET` trong CMS.
+- Thiết lập GA4 theo `NEXT_PUBLIC_GA_ID`.
+- Tạo workflows biên tập trên Strapi (Author → Editor → Publish).
+

--- a/cms/config/admin.ts
+++ b/cms/config/admin.ts
@@ -1,0 +1,6 @@
+export default ({ env }) => ({
+  auth: {
+    secret: env('ADMIN_JWT_SECRET'),
+  },
+  url: env('ADMIN_URL', '/admin'),
+});

--- a/cms/config/database.ts
+++ b/cms/config/database.ts
@@ -1,0 +1,24 @@
+import { parse } from 'pg-connection-string';
+
+export default ({ env }) => {
+  const { host, port, database, user, password } = parse(
+    env('DATABASE_URL', 'postgres://strapi:strapi@localhost:5432/strapi'),
+  );
+
+  return {
+    connection: {
+      client: 'postgres',
+      connection: {
+        host,
+        port,
+        database,
+        user,
+        password,
+        ssl: env.bool('DATABASE_SSL', false) && {
+          rejectUnauthorized: env.bool('DATABASE_SSL_SELF', false),
+        },
+      },
+      debug: false,
+    },
+  };
+};

--- a/cms/config/middlewares.ts
+++ b/cms/config/middlewares.ts
@@ -1,0 +1,19 @@
+export default [
+  'strapi::errors',
+  {
+    name: 'strapi::cors',
+    config: {
+      enabled: true,
+      headers: '*',
+      origin: ['https://thcs-abc.edu.vn', 'http://localhost:3000'],
+    },
+  },
+  'strapi::security',
+  'strapi::poweredBy',
+  'strapi::logger',
+  'strapi::query',
+  'strapi::body',
+  'strapi::session',
+  'strapi::favicon',
+  'strapi::public',
+];

--- a/cms/config/plugins.ts
+++ b/cms/config/plugins.ts
@@ -1,0 +1,24 @@
+export default ({ env }) => ({
+  seo: {
+    enabled: true,
+  },
+  graphql: {
+    enabled: true,
+    config: {
+      endpoint: '/graphql',
+      playgroundAlways: false,
+    },
+  },
+  upload: {
+    config: {
+      provider: env('CLOUDINARY_URL') ? 'cloudinary' : 'local',
+      providerOptions: env('CLOUDINARY_URL')
+        ? {
+            cloud_name: env('CLOUDINARY_CLOUD_NAME'),
+            api_key: env('CLOUDINARY_API_KEY'),
+            api_secret: env('CLOUDINARY_API_SECRET'),
+          }
+        : {},
+    },
+  },
+});

--- a/cms/config/server.ts
+++ b/cms/config/server.ts
@@ -1,0 +1,8 @@
+export default ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  app: {
+    keys: env.array('APP_KEYS'),
+  },
+  url: env('PUBLIC_URL', 'https://cms.thcs-abc.edu.vn'),
+});

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "thcs-landing-cms",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "develop": "strapi develop",
+    "start": "strapi start",
+    "build": "strapi build"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
+  "dependencies": {
+    "@strapi/plugin-seo": "^1.0.0",
+    "@strapi/plugin-sentry": "^5.0.0",
+    "@strapi/strapi": "^5.0.0",
+    "@strapi/plugin-graphql": "^5.0.0",
+    "@strapi/provider-upload-cloudinary": "^5.0.0",
+    "pg": "^8.11.5",
+    "pg-connection-string": "^2.6.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "typescript": "^5.4.5"
+  }
+}

--- a/cms/src/admin/app.ts
+++ b/cms/src/admin/app.ts
@@ -1,0 +1,10 @@
+export default {
+  config: {
+    translations: {
+      en: {
+        'app.components.LeftMenu.navbrand.title': 'THCS Xuân Cao CMS',
+      },
+    },
+  },
+  bootstrap() {},
+};

--- a/cms/src/api/about/content-types/about/schema.json
+++ b/cms/src/api/about/content-types/about/schema.json
@@ -1,0 +1,36 @@
+{
+  "kind": "singleType",
+  "collectionName": "about",
+  "info": {
+    "singularName": "about",
+    "pluralName": "abouts",
+    "displayName": "GioiThieu"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "default": "Giới thiệu"
+    },
+    "mission": {
+      "type": "richtext"
+    },
+    "vision": {
+      "type": "richtext"
+    },
+    "history": {
+      "type": "richtext"
+    },
+    "stats": {
+      "type": "component",
+      "repeatable": true,
+      "component": "shared.stat-item"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/about/controllers/about.ts
+++ b/cms/src/api/about/controllers/about.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::about.about');

--- a/cms/src/api/about/routes/about.ts
+++ b/cms/src/api/about/routes/about.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::about.about');

--- a/cms/src/api/about/services/about.ts
+++ b/cms/src/api/about/services/about.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::about.about');

--- a/cms/src/api/achievement/content-types/achievement/schema.json
+++ b/cms/src/api/achievement/content-types/achievement/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "achievements",
+  "info": {
+    "singularName": "achievement",
+    "pluralName": "achievements",
+    "displayName": "ThanhTich"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "year": {
+      "type": "integer"
+    },
+    "level": {
+      "type": "enumeration",
+      "enum": ["Quận", "Tỉnh", "Quốc gia", "Quốc tế"]
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "images": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/achievement/controllers/achievement.ts
+++ b/cms/src/api/achievement/controllers/achievement.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::achievement.achievement');

--- a/cms/src/api/achievement/routes/achievement.ts
+++ b/cms/src/api/achievement/routes/achievement.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::achievement.achievement');

--- a/cms/src/api/achievement/services/achievement.ts
+++ b/cms/src/api/achievement/services/achievement.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::achievement.achievement');

--- a/cms/src/api/album/content-types/album/schema.json
+++ b/cms/src/api/album/content-types/album/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "collectionType",
+  "collectionName": "albums",
+  "info": {
+    "singularName": "album",
+    "pluralName": "albums",
+    "displayName": "SchoolLife"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "description": {
+      "type": "text"
+    },
+    "media": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images", "videos"]
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/album/controllers/album.ts
+++ b/cms/src/api/album/controllers/album.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::album.album');

--- a/cms/src/api/album/routes/album.ts
+++ b/cms/src/api/album/routes/album.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::album.album');

--- a/cms/src/api/album/services/album.ts
+++ b/cms/src/api/album/services/album.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::album.album');

--- a/cms/src/api/announcement/content-types/announcement/schema.json
+++ b/cms/src/api/announcement/content-types/announcement/schema.json
@@ -1,0 +1,39 @@
+{
+  "kind": "collectionType",
+  "collectionName": "announcements",
+  "info": {
+    "singularName": "announcement",
+    "pluralName": "announcements",
+    "displayName": "ThongBao"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "pinned": {
+      "type": "boolean",
+      "default": false
+    },
+    "startDate": {
+      "type": "datetime"
+    },
+    "endDate": {
+      "type": "datetime"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/announcement/controllers/announcement.ts
+++ b/cms/src/api/announcement/controllers/announcement.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::announcement.announcement');

--- a/cms/src/api/announcement/routes/announcement.ts
+++ b/cms/src/api/announcement/routes/announcement.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::announcement.announcement');

--- a/cms/src/api/announcement/services/announcement.ts
+++ b/cms/src/api/announcement/services/announcement.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::announcement.announcement');

--- a/cms/src/api/category/content-types/category/schema.json
+++ b/cms/src/api/category/content-types/category/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "categories",
+  "info": {
+    "singularName": "category",
+    "pluralName": "categories",
+    "displayName": "Category"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name"
+    },
+    "parent": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::category.category"
+    }
+  }
+}

--- a/cms/src/api/category/controllers/category.ts
+++ b/cms/src/api/category/controllers/category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::category.category');

--- a/cms/src/api/category/routes/category.ts
+++ b/cms/src/api/category/routes/category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::category.category');

--- a/cms/src/api/category/services/category.ts
+++ b/cms/src/api/category/services/category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::category.category');

--- a/cms/src/api/contact/content-types/contact/schema.json
+++ b/cms/src/api/contact/content-types/contact/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "singleType",
+  "collectionName": "contact",
+  "info": {
+    "singularName": "contact",
+    "pluralName": "contacts",
+    "displayName": "LienHe"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "default": "Liên hệ"
+    },
+    "description": {
+      "type": "text"
+    },
+    "address": {
+      "type": "string"
+    },
+    "email": {
+      "type": "email"
+    },
+    "phone": {
+      "type": "string"
+    },
+    "mapEmbed": {
+      "type": "richtext"
+    },
+    "formEndpoint": {
+      "type": "string"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/contact/controllers/contact.ts
+++ b/cms/src/api/contact/controllers/contact.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::contact.contact');

--- a/cms/src/api/contact/routes/contact.ts
+++ b/cms/src/api/contact/routes/contact.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::contact.contact');

--- a/cms/src/api/contact/services/contact.ts
+++ b/cms/src/api/contact/services/contact.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::contact.contact');

--- a/cms/src/api/event/content-types/event/schema.json
+++ b/cms/src/api/event/content-types/event/schema.json
@@ -1,0 +1,52 @@
+{
+  "kind": "collectionType",
+  "collectionName": "events",
+  "info": {
+    "singularName": "event",
+    "pluralName": "events",
+    "displayName": "SuKien"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "startDate": {
+      "type": "datetime",
+      "required": true
+    },
+    "endDate": {
+      "type": "datetime"
+    },
+    "location": {
+      "type": "string"
+    },
+    "coverImage": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images", "videos"]
+    },
+    "rsvpLink": {
+      "type": "string"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/event/controllers/event.ts
+++ b/cms/src/api/event/controllers/event.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::event.event');

--- a/cms/src/api/event/routes/event.ts
+++ b/cms/src/api/event/routes/event.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::event.event');

--- a/cms/src/api/event/services/event.ts
+++ b/cms/src/api/event/services/event.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::event.event');

--- a/cms/src/api/homepage/content-types/homepage/schema.json
+++ b/cms/src/api/homepage/content-types/homepage/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "singleType",
+  "collectionName": "homepage",
+  "info": {
+    "singularName": "homepage",
+    "pluralName": "homepages",
+    "displayName": "HomePage"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "hero": {
+      "type": "component",
+      "component": "blocks.hero"
+    },
+    "news": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::post.post"
+    },
+    "events": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::event.event"
+    },
+    "schoolLife": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::album.album"
+    },
+    "testimonials": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::testimonial.testimonial"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/homepage/controllers/homepage.ts
+++ b/cms/src/api/homepage/controllers/homepage.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::homepage.homepage');

--- a/cms/src/api/homepage/routes/homepage.ts
+++ b/cms/src/api/homepage/routes/homepage.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::homepage.homepage');

--- a/cms/src/api/homepage/services/homepage.ts
+++ b/cms/src/api/homepage/services/homepage.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::homepage.homepage');

--- a/cms/src/api/organization/content-types/organization/schema.json
+++ b/cms/src/api/organization/content-types/organization/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "singleType",
+  "collectionName": "organization",
+  "info": {
+    "singularName": "organization",
+    "pluralName": "organizations",
+    "displayName": "ThongTinTruong"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "legalName": {
+      "type": "string",
+      "required": true
+    },
+    "logo": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "foundingDate": {
+      "type": "date"
+    },
+    "sameAs": {
+      "type": "json"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/organization/controllers/organization.ts
+++ b/cms/src/api/organization/controllers/organization.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::organization.organization');

--- a/cms/src/api/organization/routes/organization.ts
+++ b/cms/src/api/organization/routes/organization.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::organization.organization');

--- a/cms/src/api/organization/services/organization.ts
+++ b/cms/src/api/organization/services/organization.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::organization.organization');

--- a/cms/src/api/post/content-types/post/schema.json
+++ b/cms/src/api/post/content-types/post/schema.json
@@ -1,0 +1,64 @@
+{
+  "kind": "collectionType",
+  "collectionName": "posts",
+  "info": {
+    "singularName": "post",
+    "pluralName": "posts",
+    "displayName": "BaiViet"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "content-manager": {
+      "visible": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "excerpt": {
+      "type": "text"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "coverImage": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images", "videos"]
+    },
+    "tags": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::tag.tag"
+    },
+    "category": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::category.category"
+    },
+    "author": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::teacher.teacher"
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/post/controllers/post.ts
+++ b/cms/src/api/post/controllers/post.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::post.post');

--- a/cms/src/api/post/routes/post.ts
+++ b/cms/src/api/post/routes/post.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::post.post');

--- a/cms/src/api/post/services/post.ts
+++ b/cms/src/api/post/services/post.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::post.post');

--- a/cms/src/api/tag/content-types/tag/schema.json
+++ b/cms/src/api/tag/content-types/tag/schema.json
@@ -1,0 +1,22 @@
+{
+  "kind": "collectionType",
+  "collectionName": "tags",
+  "info": {
+    "singularName": "tag",
+    "pluralName": "tags",
+    "displayName": "Tag"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name"
+    }
+  }
+}

--- a/cms/src/api/tag/controllers/tag.ts
+++ b/cms/src/api/tag/controllers/tag.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::tag.tag');

--- a/cms/src/api/tag/routes/tag.ts
+++ b/cms/src/api/tag/routes/tag.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::tag.tag');

--- a/cms/src/api/tag/services/tag.ts
+++ b/cms/src/api/tag/services/tag.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::tag.tag');

--- a/cms/src/api/teacher/content-types/teacher/schema.json
+++ b/cms/src/api/teacher/content-types/teacher/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "collectionType",
+  "collectionName": "teachers",
+  "info": {
+    "singularName": "teacher",
+    "pluralName": "teachers",
+    "displayName": "GiaoVien"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name"
+    },
+    "photo": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "position": {
+      "type": "string"
+    },
+    "bio": {
+      "type": "richtext"
+    },
+    "achievements": {
+      "type": "component",
+      "repeatable": true,
+      "component": "shared.achievement-item"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/teacher/controllers/teacher.ts
+++ b/cms/src/api/teacher/controllers/teacher.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::teacher.teacher');

--- a/cms/src/api/teacher/routes/teacher.ts
+++ b/cms/src/api/teacher/routes/teacher.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::teacher.teacher');

--- a/cms/src/api/teacher/services/teacher.ts
+++ b/cms/src/api/teacher/services/teacher.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::teacher.teacher');

--- a/cms/src/api/testimonial/content-types/testimonial/schema.json
+++ b/cms/src/api/testimonial/content-types/testimonial/schema.json
@@ -1,0 +1,38 @@
+{
+  "kind": "collectionType",
+  "collectionName": "testimonials",
+  "info": {
+    "singularName": "testimonial",
+    "pluralName": "testimonials",
+    "displayName": "GocNhin"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "role": {
+      "type": "string"
+    },
+    "quote": {
+      "type": "text",
+      "required": true
+    },
+    "avatar": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/cms/src/api/testimonial/controllers/testimonial.ts
+++ b/cms/src/api/testimonial/controllers/testimonial.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::testimonial.testimonial');

--- a/cms/src/api/testimonial/routes/testimonial.ts
+++ b/cms/src/api/testimonial/routes/testimonial.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::testimonial.testimonial');

--- a/cms/src/api/testimonial/services/testimonial.ts
+++ b/cms/src/api/testimonial/services/testimonial.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::testimonial.testimonial');

--- a/cms/src/components/blocks/hero.json
+++ b/cms/src/components/blocks/hero.json
@@ -1,0 +1,30 @@
+{
+  "collectionName": "components_blocks_hero",
+  "info": {
+    "displayName": "Hero"
+  },
+  "attributes": {
+    "headline": {
+      "type": "string",
+      "required": true
+    },
+    "subheadline": {
+      "type": "text"
+    },
+    "media": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images", "videos"]
+    },
+    "primaryCta": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.cta"
+    },
+    "secondaryCta": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.cta"
+    }
+  }
+}

--- a/cms/src/components/shared/achievement-item.json
+++ b/cms/src/components/shared/achievement-item.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_shared_achievement_items",
+  "info": {
+    "displayName": "Achievement"
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "year": {
+      "type": "integer"
+    },
+    "level": {
+      "type": "string"
+    },
+    "description": {
+      "type": "text"
+    }
+  }
+}

--- a/cms/src/components/shared/cta.json
+++ b/cms/src/components/shared/cta.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_shared_cta",
+  "info": {
+    "displayName": "CTA"
+  },
+  "attributes": {
+    "label": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/cms/src/components/shared/seo.json
+++ b/cms/src/components/shared/seo.json
@@ -1,0 +1,26 @@
+{
+  "collectionName": "components_shared_seo",
+  "info": {
+    "displayName": "SEO",
+    "description": "SEO meta fields"
+  },
+  "attributes": {
+    "metaTitle": {
+      "type": "string",
+      "maxLength": 70,
+      "required": false
+    },
+    "metaDescription": {
+      "type": "text",
+      "maxLength": 160
+    },
+    "ogImage": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": ["images"]
+    },
+    "canonicalURL": {
+      "type": "string"
+    }
+  }
+}

--- a/cms/src/components/shared/stat-item.json
+++ b/cms/src/components/shared/stat-item.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_shared_stat_items",
+  "info": {
+    "displayName": "Stat",
+    "description": "Statistic item"
+  },
+  "attributes": {
+    "label": {
+      "type": "string",
+      "required": true
+    },
+    "value": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1,0 +1,4 @@
+export default {
+  register() {},
+  bootstrap() {},
+};

--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,20 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+      {
+        protocol: 'http',
+        hostname: '**',
+      },
+    ],
+  },
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "thcs-landing-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.19",
+    "clsx": "^2.1.1",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/(public)/cuoc-song-hoc-duong/[slug]/page.tsx
+++ b/frontend/src/app/(public)/cuoc-song-hoc-duong/[slug]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from 'next/navigation';
+import Image from 'next/image';
+import PageHeader from '@/components/PageHeader';
+import { fetchAlbumBySlug } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { getMediaAlt, getMediaUrl } from '@/lib/image';
+import { Metadata } from 'next';
+
+interface AlbumPageProps {
+  params: { slug: string };
+}
+
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: AlbumPageProps): Promise<Metadata> {
+  const album = await fetchAlbumBySlug(params.slug);
+  if (!album) return {};
+  return buildSeoMetadata(album.seo, {
+    title: `${album.title} - Đời sống học đường`,
+    description: album.description ?? undefined,
+  });
+}
+
+export default async function AlbumPage({ params }: AlbumPageProps) {
+  const album = await fetchAlbumBySlug(params.slug);
+  if (!album) notFound();
+
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Đời sống học đường', href: '/cuoc-song-hoc-duong' },
+    { label: album.title, href: `/cuoc-song-hoc-duong/${album.slug}` },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+
+  return (
+    <article className="pb-16">
+      <PageHeader
+        title={album.title}
+        description={album.description}
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <div className="grid gap-4 md:grid-cols-2">
+          {album.media?.map((media) => {
+            const url = getMediaUrl(media);
+            if (!url) return null;
+            return (
+              <div key={media.id} className="relative aspect-[4/3] overflow-hidden rounded-3xl">
+                <Image
+                  src={url}
+                  alt={getMediaAlt(media, album.title)}
+                  fill
+                  className="object-cover"
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </article>
+  );
+}

--- a/frontend/src/app/(public)/cuoc-song-hoc-duong/page.tsx
+++ b/frontend/src/app/(public)/cuoc-song-hoc-duong/page.tsx
@@ -1,0 +1,42 @@
+import PageHeader from '@/components/PageHeader';
+import Gallery from '@/components/Gallery';
+import { fetchAlbums } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+export const revalidate = 1800;
+
+export const metadata: Metadata = buildSeoMetadata(
+  {
+    metaTitle: 'Đời sống học đường - Trường THCS Xuân Cao',
+    metaDescription: 'Hình ảnh, video ghi lại khoảnh khắc đáng nhớ của học sinh Trường THCS Xuân Cao.',
+  },
+  {
+    title: 'Đời sống học đường - Trường THCS Xuân Cao',
+    description: 'Hình ảnh, video ghi lại khoảnh khắc đáng nhớ của học sinh Trường THCS Xuân Cao.',
+  },
+);
+
+export default async function SchoolLifePage() {
+  const albumsRes = await fetchAlbums();
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Đời sống học đường', href: '/cuoc-song-hoc-duong' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title="Đời sống học đường"
+        description="Những khoảnh khắc đáng nhớ trong hành trình học tập và rèn luyện của học sinh."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <Gallery items={albumsRes.data} />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/doi-ngu/[slug]/page.tsx
+++ b/frontend/src/app/(public)/doi-ngu/[slug]/page.tsx
@@ -1,0 +1,75 @@
+import { notFound } from 'next/navigation';
+import PageHeader from '@/components/PageHeader';
+import RichText from '@/components/RichText';
+import { fetchTeacherBySlug } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+interface TeacherPageProps {
+  params: { slug: string };
+}
+
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: TeacherPageProps): Promise<Metadata> {
+  const teacher = await fetchTeacherBySlug(params.slug);
+  if (!teacher) return {};
+  return buildSeoMetadata(teacher.seo, {
+    title: `${teacher.name} - Đội ngũ Xuân Cao`,
+    description: teacher.position ?? undefined,
+  });
+}
+
+export default async function TeacherPage({ params }: TeacherPageProps) {
+  const teacher = await fetchTeacherBySlug(params.slug);
+  if (!teacher) notFound();
+
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Đội ngũ', href: '/doi-ngu' },
+    { label: teacher.name, href: `/doi-ngu/${teacher.slug}` },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+
+  return (
+    <article className="pb-16">
+      <PageHeader
+        title={teacher.name}
+        description={teacher.position}
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container space-y-12 py-12">
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-900">Giới thiệu</h2>
+          <div className="mt-4">
+            <RichText html={teacher.bio} />
+          </div>
+        </section>
+        {teacher.achievements && teacher.achievements.length > 0 && (
+          <section>
+            <h2 className="text-2xl font-semibold text-slate-900">Thành tích tiêu biểu</h2>
+            <div className="mt-4 grid gap-4 lg:grid-cols-2">
+              {teacher.achievements.map((achievement) => (
+                <div key={achievement.id} className="rounded-2xl border border-slate-200 p-6">
+                  <h3 className="text-lg font-semibold text-primary-700">{achievement.title}</h3>
+                  {achievement.year && (
+                    <p className="text-sm text-slate-500">Năm: {achievement.year}</p>
+                  )}
+                  {achievement.level && (
+                    <p className="text-sm text-slate-500">Cấp độ: {achievement.level}</p>
+                  )}
+                  {achievement.description && (
+                    <p className="mt-2 text-sm text-slate-600">{achievement.description}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </article>
+  );
+}

--- a/frontend/src/app/(public)/doi-ngu/page.tsx
+++ b/frontend/src/app/(public)/doi-ngu/page.tsx
@@ -1,0 +1,52 @@
+import PageHeader from '@/components/PageHeader';
+import Card from '@/components/Card';
+import { fetchTeachers } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+export const revalidate = 1800;
+
+export const metadata: Metadata = buildSeoMetadata(
+  {
+    metaTitle: 'Đội ngũ - Trường THCS Xuân Cao',
+    metaDescription: 'Gặp gỡ đội ngũ giáo viên và cán bộ tận tâm của Trường THCS Xuân Cao.',
+  },
+  {
+    title: 'Đội ngũ - Trường THCS Xuân Cao',
+    description: 'Gặp gỡ đội ngũ giáo viên và cán bộ tận tâm của Trường THCS Xuân Cao.',
+  },
+);
+
+export default async function TeachersPage() {
+  const teachersRes = await fetchTeachers();
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Đội ngũ', href: '/doi-ngu' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title="Đội ngũ giáo viên"
+        description="Những nhà giáo giàu kinh nghiệm, tận tâm đồng hành cùng học sinh."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {teachersRes.data.map((teacher) => (
+            <Card
+              key={teacher.id}
+              href={`/doi-ngu/${teacher.slug}`}
+              title={teacher.name}
+              description={teacher.position}
+              media={teacher.photo}
+            />
+          ))}
+        </div>
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/gioi-thieu/page.tsx
+++ b/frontend/src/app/(public)/gioi-thieu/page.tsx
@@ -1,0 +1,67 @@
+import PageHeader from '@/components/PageHeader';
+import RichText from '@/components/RichText';
+import { fetchAboutPage } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+export const revalidate = 3600;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const about = await fetchAboutPage();
+  return buildSeoMetadata(about.seo, {
+    title: about.title ?? 'Giới thiệu',
+    description: 'Thông tin về sứ mệnh, tầm nhìn và lịch sử Trường THCS Xuân Cao.',
+  });
+}
+
+export default async function AboutPage() {
+  const about = await fetchAboutPage();
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Giới thiệu', href: '/gioi-thieu' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title={about.title ?? 'Giới thiệu'}
+        description="Khám phá sứ mệnh, tầm nhìn và câu chuyện phát triển của Trường THCS Xuân Cao."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container space-y-12 py-12">
+        <section className="grid gap-8 lg:grid-cols-2">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900">Sứ mệnh</h2>
+            <RichText html={about.mission} />
+          </div>
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900">Tầm nhìn</h2>
+            <RichText html={about.vision} />
+          </div>
+        </section>
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-900">Lịch sử hình thành</h2>
+          <div className="mt-4">
+            <RichText html={about.history} />
+          </div>
+        </section>
+        {about.stats && about.stats.length > 0 && (
+          <section className="rounded-3xl bg-primary-50 p-8">
+            <h2 className="text-2xl font-semibold text-slate-900">Những con số nổi bật</h2>
+            <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {about.stats.map((stat) => (
+                <div key={stat.id} className="rounded-2xl bg-white p-6 shadow">
+                  <p className="text-3xl font-bold text-primary-600">{stat.value}</p>
+                  <p className="mt-2 text-sm text-slate-600">{stat.label}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/goc-nhin/page.tsx
+++ b/frontend/src/app/(public)/goc-nhin/page.tsx
@@ -1,0 +1,42 @@
+import PageHeader from '@/components/PageHeader';
+import Testimonials from '@/components/Testimonials';
+import { fetchTestimonials } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = buildSeoMetadata(
+  {
+    metaTitle: 'Góc nhìn - Trường THCS Xuân Cao',
+    metaDescription: 'Lắng nghe chia sẻ từ phụ huynh, học sinh và giáo viên Trường THCS Xuân Cao.',
+  },
+  {
+    title: 'Góc nhìn - Trường THCS Xuân Cao',
+    description: 'Lắng nghe chia sẻ từ phụ huynh, học sinh và giáo viên Trường THCS Xuân Cao.',
+  },
+);
+
+export default async function TestimonialsPage() {
+  const testimonials = await fetchTestimonials();
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Góc nhìn', href: '/goc-nhin' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title="Góc nhìn từ cộng đồng"
+        description="Những cảm nhận chân thành từ phụ huynh, học sinh và giáo viên Xuân Cao."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <Testimonials testimonials={testimonials} />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/lien-he/page.tsx
+++ b/frontend/src/app/(public)/lien-he/page.tsx
@@ -1,0 +1,68 @@
+import PageHeader from '@/components/PageHeader';
+import ContactForm from '@/components/forms/ContactForm';
+import RichText from '@/components/RichText';
+import { fetchContactPage } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+export const revalidate = 1800;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const contact = await fetchContactPage();
+  return buildSeoMetadata(contact.seo, {
+    title: contact.title ?? 'Liên hệ',
+    description: contact.description ?? undefined,
+  });
+}
+
+export default async function ContactPage() {
+  const contact = await fetchContactPage();
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Liên hệ', href: '/lien-he' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title={contact.title ?? 'Liên hệ'}
+        description={contact.description ?? 'Chúng tôi sẵn sàng đồng hành cùng bạn.'}
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container grid gap-12 py-12 lg:grid-cols-[2fr,3fr]">
+        <div className="space-y-6 rounded-3xl bg-primary-50 p-8">
+          <h2 className="text-xl font-semibold text-slate-900">Thông tin liên hệ</h2>
+          <ul className="space-y-3 text-sm text-slate-600">
+            {contact.address && (
+              <li>
+                <span className="font-semibold text-slate-900">Địa chỉ:</span> {contact.address}
+              </li>
+            )}
+            {contact.email && (
+              <li>
+                <span className="font-semibold text-slate-900">Email:</span>{' '}
+                <a className="text-primary-600" href={`mailto:${contact.email}`}>
+                  {contact.email}
+                </a>
+              </li>
+            )}
+            {contact.phone && (
+              <li>
+                <span className="font-semibold text-slate-900">Điện thoại:</span>{' '}
+                <a className="text-primary-600" href={`tel:${contact.phone}`}>
+                  {contact.phone}
+                </a>
+              </li>
+            )}
+          </ul>
+          {contact.mapEmbed && <RichText html={contact.mapEmbed} />}
+        </div>
+        <ContactForm endpoint={contact.formEndpoint} />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -1,0 +1,38 @@
+import { Metadata } from 'next';
+import Hero from '@/components/Hero';
+import NewsGrid from '@/components/NewsGrid';
+import EventsList from '@/components/EventsList';
+import Gallery from '@/components/Gallery';
+import Testimonials from '@/components/Testimonials';
+import { fetchHomePage } from '@/lib/api';
+import { buildHomeMetadata } from '@/lib/seo';
+
+export const revalidate = 3600;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchHomePage();
+  return buildHomeMetadata(data);
+}
+
+export default async function HomePage() {
+  const data = await fetchHomePage();
+  return (
+    <div className="space-y-16 pb-16">
+      <Hero data={data.hero} />
+      <section className="container">
+        <NewsGrid posts={data.news} />
+      </section>
+      <section className="container">
+        <EventsList events={data.events} />
+      </section>
+      <section className="container">
+        <Gallery items={data.schoolLife} />
+      </section>
+      <section className="bg-primary-50 py-16">
+        <div className="container">
+          <Testimonials testimonials={data.testimonials} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/su-kien/[slug]/page.tsx
+++ b/frontend/src/app/(public)/su-kien/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import { notFound } from 'next/navigation';
+import PageHeader from '@/components/PageHeader';
+import RichText from '@/components/RichText';
+import { fetchEventBySlug } from '@/lib/api';
+import { buildEventMetadata, buildEventJsonLd, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { formatDateRange } from '@/lib/utils';
+
+interface EventPageProps {
+  params: { slug: string };
+}
+
+export const revalidate = 1800;
+
+export async function generateMetadata({ params }: EventPageProps) {
+  const event = await fetchEventBySlug(params.slug);
+  if (!event) return {};
+  return buildEventMetadata(event);
+}
+
+export default async function EventPage({ params }: EventPageProps) {
+  const event = await fetchEventBySlug(params.slug);
+  if (!event) notFound();
+
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Sự kiện', href: '/su-kien' },
+    { label: event.title, href: `/su-kien/${event.slug}` },
+  ];
+
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  const eventJsonLd = buildEventJsonLd(event);
+
+  return (
+    <article className="pb-16">
+      <PageHeader
+        title={event.title}
+        description={event.description}
+        breadcrumbs={breadcrumbs}
+        actions={
+          <p className="text-sm text-slate-500">{formatDateRange(event.startDate, event.endDate)}</p>
+        }
+      />
+      <div className="container space-y-8 py-12">
+        <RichText html={event.description} />
+        {event.rsvpLink && (
+          <a
+            href={event.rsvpLink}
+            className="inline-flex items-center rounded-full bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-primary-700"
+          >
+            Đăng ký tham gia
+          </a>
+        )}
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(eventJsonLd)}
+      </script>
+    </article>
+  );
+}

--- a/frontend/src/app/(public)/su-kien/page.tsx
+++ b/frontend/src/app/(public)/su-kien/page.tsx
@@ -1,0 +1,107 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import PageHeader from '@/components/PageHeader';
+import Card from '@/components/Card';
+import { fetchEvents } from '@/lib/api';
+import { formatDateRange } from '@/lib/utils';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+
+export const revalidate = 1800;
+
+export const metadata: Metadata = buildSeoMetadata(
+  {
+    metaTitle: 'Sự kiện - Trường THCS Xuân Cao',
+    metaDescription: 'Theo dõi các sự kiện nổi bật tại Trường THCS Xuân Cao.',
+  },
+  {
+    title: 'Sự kiện - Trường THCS Xuân Cao',
+    description: 'Theo dõi các sự kiện nổi bật tại Trường THCS Xuân Cao.',
+  },
+);
+
+type EventsPageProps = {
+  searchParams: {
+    page?: string;
+  };
+};
+
+export default async function EventsPage({ searchParams }: EventsPageProps) {
+  const page = Number(searchParams.page ?? '1') || 1;
+  const eventsRes = await fetchEvents(page);
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Sự kiện', href: '/su-kien' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title="Sự kiện"
+        description="Lịch hoạt động, chương trình và sự kiện quan trọng của Trường THCS Xuân Cao."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <div className="grid gap-6 md:grid-cols-2">
+          {eventsRes.data.map((event) => (
+            <Card
+              key={event.id}
+              href={`/su-kien/${event.slug}`}
+              title={event.title}
+              description={event.description}
+              media={event.coverImage}
+              meta={formatDateRange(event.startDate, event.endDate)}
+            />
+          ))}
+        </div>
+        <Pagination
+          currentPage={eventsRes.pagination.page}
+          totalPages={eventsRes.pagination.pageCount}
+          basePath="/su-kien"
+        />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}
+
+function Pagination({
+  currentPage,
+  totalPages,
+  basePath,
+}: {
+  currentPage: number;
+  totalPages: number;
+  basePath: string;
+}) {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="mt-12 flex items-center justify-center gap-4">
+      {currentPage > 1 ? (
+        <Link
+          href={`${basePath}?page=${currentPage - 1}`}
+          className="rounded-full border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:border-primary-500 hover:text-primary-600"
+        >
+          ← Trang trước
+        </Link>
+      ) : (
+        <span className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-400">← Trang trước</span>
+      )}
+      <span className="text-sm text-slate-600">
+        Trang {currentPage} / {totalPages}
+      </span>
+      {currentPage < totalPages ? (
+        <Link
+          href={`${basePath}?page=${currentPage + 1}`}
+          className="rounded-full border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:border-primary-500 hover:text-primary-600"
+        >
+          Trang tiếp →
+        </Link>
+      ) : (
+        <span className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-400">Trang tiếp →</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/thanh-tich/[slug]/page.tsx
+++ b/frontend/src/app/(public)/thanh-tich/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from 'next/navigation';
+import PageHeader from '@/components/PageHeader';
+import RichText from '@/components/RichText';
+import { fetchAchievementBySlug } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+interface AchievementPageProps {
+  params: { slug: string };
+}
+
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: AchievementPageProps): Promise<Metadata> {
+  const achievement = await fetchAchievementBySlug(params.slug);
+  if (!achievement) return {};
+  return buildSeoMetadata(achievement.seo, {
+    title: `${achievement.title} - Thành tích Xuân Cao`,
+    description: achievement.description ?? undefined,
+  });
+}
+
+export default async function AchievementPage({ params }: AchievementPageProps) {
+  const achievement = await fetchAchievementBySlug(params.slug);
+  if (!achievement) notFound();
+
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Thành tích', href: '/thanh-tich' },
+    { label: achievement.title, href: `/thanh-tich/${achievement.slug}` },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+
+  return (
+    <article className="pb-16">
+      <PageHeader
+        title={achievement.title}
+        description={achievement.level}
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container space-y-6 py-12">
+        {achievement.year && <p className="text-sm text-slate-500">Năm: {achievement.year}</p>}
+        <RichText html={achievement.description} />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </article>
+  );
+}

--- a/frontend/src/app/(public)/thanh-tich/page.tsx
+++ b/frontend/src/app/(public)/thanh-tich/page.tsx
@@ -1,0 +1,51 @@
+import PageHeader from '@/components/PageHeader';
+import Card from '@/components/Card';
+import { fetchAchievements } from '@/lib/api';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { Metadata } from 'next';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = buildSeoMetadata(
+  {
+    metaTitle: 'Thành tích - Trường THCS Xuân Cao',
+    metaDescription: 'Tự hào thành tích học sinh và giáo viên Trường THCS Xuân Cao.',
+  },
+  {
+    title: 'Thành tích - Trường THCS Xuân Cao',
+    description: 'Tự hào thành tích học sinh và giáo viên Trường THCS Xuân Cao.',
+  },
+);
+
+export default async function AchievementsPage() {
+  const achievementsRes = await fetchAchievements();
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Thành tích', href: '/thanh-tich' },
+  ];
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title="Thành tích nổi bật"
+        description="Ghi dấu những thành tựu học thuật và hoạt động của thầy trò Xuân Cao."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <div className="grid gap-6 md:grid-cols-2">
+          {achievementsRes.data.map((achievement) => (
+            <Card
+              key={achievement.id}
+              href={`/thanh-tich/${achievement.slug}`}
+              title={achievement.title}
+              description={achievement.description}
+            />
+          ))}
+        </div>
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/tin-tuc/[slug]/page.tsx
+++ b/frontend/src/app/(public)/tin-tuc/[slug]/page.tsx
@@ -1,0 +1,56 @@
+import { notFound } from 'next/navigation';
+import PageHeader from '@/components/PageHeader';
+import RichText from '@/components/RichText';
+import { fetchPostBySlug } from '@/lib/api';
+import { buildArticleJsonLd, buildArticleMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+import { formatDate } from '@/lib/utils';
+
+interface PostPageProps {
+  params: { slug: string };
+}
+
+export const revalidate = 3600;
+
+export async function generateMetadata({ params }: PostPageProps) {
+  const post = await fetchPostBySlug(params.slug);
+  if (!post) return {};
+  return buildArticleMetadata(post);
+}
+
+export default async function PostPage({ params }: PostPageProps) {
+  const post = await fetchPostBySlug(params.slug);
+  if (!post) notFound();
+
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Tin tức', href: '/tin-tuc' },
+    { label: post.title, href: `/tin-tuc/${post.slug}` },
+  ];
+
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+  const articleJsonLd = buildArticleJsonLd(post);
+
+  return (
+    <article className="pb-16">
+      <PageHeader
+        title={post.title}
+        description={post.excerpt}
+        breadcrumbs={breadcrumbs}
+        actions={
+          post.publishedAt && (
+            <p className="text-sm text-slate-500">Cập nhật: {formatDate(post.publishedAt)}</p>
+          )
+        }
+      />
+      <div className="container py-12">
+        <RichText html={post.content} />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(articleJsonLd)}
+      </script>
+    </article>
+  );
+}

--- a/frontend/src/app/(public)/tin-tuc/page.tsx
+++ b/frontend/src/app/(public)/tin-tuc/page.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+import { Metadata } from 'next';
+import PageHeader from '@/components/PageHeader';
+import Card from '@/components/Card';
+import { fetchPosts } from '@/lib/api';
+import { formatDate } from '@/lib/utils';
+import { buildSeoMetadata, buildBreadcrumbJsonLd } from '@/lib/seo';
+
+export const revalidate = 1800;
+
+export const metadata: Metadata = buildSeoMetadata(
+  {
+    metaTitle: 'Tin tức - Trường THCS Xuân Cao',
+    metaDescription: 'Cập nhật tin tức mới nhất về các hoạt động, thành tích của Trường THCS Xuân Cao.',
+  },
+  {
+    title: 'Tin tức - Trường THCS Xuân Cao',
+    description: 'Cập nhật tin tức mới nhất về các hoạt động, thành tích của Trường THCS Xuân Cao.',
+  },
+);
+
+type NewsPageProps = {
+  searchParams: {
+    page?: string;
+  };
+};
+
+export default async function NewsPage({ searchParams }: NewsPageProps) {
+  const page = Number(searchParams.page ?? '1') || 1;
+  const postsRes = await fetchPosts(page);
+  const breadcrumbs = [
+    { label: 'Trang chủ', href: '/' },
+    { label: 'Tin tức', href: '/tin-tuc' },
+  ];
+
+  const jsonLd = buildBreadcrumbJsonLd(breadcrumbs);
+
+  return (
+    <div className="pb-16">
+      <PageHeader
+        title="Tin tức"
+        description="Những câu chuyện, hoạt động và thông tin mới nhất từ Trường THCS Xuân Cao."
+        breadcrumbs={breadcrumbs}
+      />
+      <div className="container py-12">
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {postsRes.data.map((post) => (
+            <Card
+              key={post.id}
+              href={`/tin-tuc/${post.slug}`}
+              title={post.title}
+              description={post.excerpt}
+              media={post.coverImage}
+              meta={post.publishedAt ? formatDate(post.publishedAt) : undefined}
+            />
+          ))}
+        </div>
+        <Pagination
+          currentPage={postsRes.pagination.page}
+          totalPages={postsRes.pagination.pageCount}
+          basePath="/tin-tuc"
+        />
+      </div>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(jsonLd)}
+      </script>
+    </div>
+  );
+}
+
+function Pagination({
+  currentPage,
+  totalPages,
+  basePath,
+}: {
+  currentPage: number;
+  totalPages: number;
+  basePath: string;
+}) {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="mt-12 flex items-center justify-center gap-4">
+      {currentPage > 1 ? (
+        <Link
+          href={`${basePath}?page=${currentPage - 1}`}
+          className="rounded-full border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:border-primary-500 hover:text-primary-600"
+        >
+          ← Trang trước
+        </Link>
+      ) : (
+        <span className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-400">← Trang trước</span>
+      )}
+      <span className="text-sm text-slate-600">
+        Trang {currentPage} / {totalPages}
+      </span>
+      {currentPage < totalPages ? (
+        <Link
+          href={`${basePath}?page=${currentPage + 1}`}
+          className="rounded-full border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:border-primary-500 hover:text-primary-600"
+        >
+          Trang tiếp →
+        </Link>
+      ) : (
+        <span className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-400">Trang tiếp →</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,1 @@
+@import '../styles/globals.css';

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from 'next';
+import { Plus_Jakarta_Sans } from 'next/font/google';
+import './globals.css';
+import clsx from 'clsx';
+import { fetchOrganizationProfile } from '@/lib/api';
+import { absoluteUrl } from '@/lib/seo';
+
+const font = Plus_Jakarta_Sans({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+});
+
+export const metadata: Metadata = {
+  title: 'Trường THCS Xuân Cao',
+  description:
+    'Website chính thức của Trường THCS Xuân Cao - cập nhật tin tức, sự kiện và thành tích nổi bật.',
+  metadataBase: new URL('https://thcs-abc.edu.vn'),
+};
+
+export default async function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const organization = await fetchOrganizationProfile();
+  const organizationJsonLd = organization
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: organization.legalName,
+        legalName: organization.legalName,
+        url: absoluteUrl('/'),
+        logo: organization.logo?.url ? absoluteUrl(organization.logo.url) : undefined,
+        foundingDate: organization.foundingDate ?? undefined,
+        sameAs: organization.sameAs ?? undefined,
+      }
+    : null;
+  return (
+    <html lang="vi" className={font.variable}>
+      <body className={clsx(font.className, 'bg-slate-50 text-slate-900')}>
+        <div className="flex min-h-screen flex-col">
+          <header className="border-b border-slate-200 bg-white/80 backdrop-blur">
+            <div className="container flex h-16 items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary-500 font-semibold text-white">
+                  TH
+                </span>
+                <div>
+                  <p className="text-sm font-medium uppercase tracking-wide text-primary-600">
+                    Trường THCS
+                  </p>
+                  <p className="text-lg font-semibold text-slate-900">Xuân Cao</p>
+                </div>
+              </div>
+              <nav className="hidden items-center gap-6 text-sm font-medium md:flex">
+                <a href="/">Trang chủ</a>
+                <a href="/tin-tuc">Tin tức</a>
+                <a href="/su-kien">Sự kiện</a>
+                <a href="/gioi-thieu">Giới thiệu</a>
+                <a href="/doi-ngu">Đội ngũ</a>
+                <a href="/thanh-tich">Thành tích</a>
+                <a href="/cuoc-song-hoc-duong">Đời sống</a>
+                <a href="/goc-nhin">Góc nhìn</a>
+                <a href="/lien-he">Liên hệ</a>
+              </nav>
+            </div>
+          </header>
+          <main className="flex-1">{children}</main>
+          <footer className="border-t border-slate-200 bg-white py-12">
+            <div className="container grid gap-8 md:grid-cols-3">
+              <div>
+                <p className="text-lg font-semibold text-slate-900">Trường THCS Xuân Cao</p>
+                <p className="mt-2 text-sm text-slate-600">
+                  Nơi nuôi dưỡng tri thức, phát triển toàn diện cho học sinh THCS.
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                  Liên hệ
+                </p>
+                <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                  <li>Email: info@thcs-abc.edu.vn</li>
+                  <li>Điện thoại: (024) 1234 5678</li>
+                  <li>Địa chỉ: Số 1 Xuân Cao, Thanh Hóa</li>
+                </ul>
+              </div>
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                  Kết nối
+                </p>
+                <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                  <li>
+                    <a href="https://facebook.com" target="_blank" rel="noreferrer">
+                      Facebook
+                    </a>
+                  </li>
+                  <li>
+                    <a href="https://youtube.com" target="_blank" rel="noreferrer">
+                      YouTube
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <div className="container mt-8 border-t border-slate-200 pt-6 text-xs text-slate-500">
+              © {new Date().getFullYear()} Trường THCS Xuân Cao. Bảo lưu mọi quyền.
+            </div>
+          </footer>
+        </div>
+        {organizationJsonLd && (
+          <script type="application/ld+json" suppressHydrationWarning>
+            {JSON.stringify(organizationJsonLd)}
+          </script>
+        )}
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/robots.txt/route.ts
+++ b/frontend/src/app/robots.txt/route.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://thcs-abc.edu.vn';
+
+export function GET(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: [`${SITE_URL}/sitemap.xml`],
+    host: SITE_URL,
+  };
+}

--- a/frontend/src/app/sitemap.xml/route.ts
+++ b/frontend/src/app/sitemap.xml/route.ts
@@ -1,0 +1,57 @@
+import { MetadataRoute } from 'next';
+import {
+  fetchPosts,
+  fetchEvents,
+  fetchTeachers,
+  fetchAchievements,
+  fetchAlbums,
+} from '@/lib/api';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://thcs-abc.edu.vn';
+
+export async function GET(): Promise<MetadataRoute.Sitemap> {
+  const [posts, events, teachers, achievements, albums] = await Promise.all([
+    fetchPosts(1, 100),
+    fetchEvents(1, 100),
+    fetchTeachers(),
+    fetchAchievements(),
+    fetchAlbums(),
+  ]);
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    '',
+    '/tin-tuc',
+    '/su-kien',
+    '/gioi-thieu',
+    '/doi-ngu',
+    '/thanh-tich',
+    '/cuoc-song-hoc-duong',
+    '/goc-nhin',
+    '/lien-he',
+  ].map((path) => ({ url: `${SITE_URL}${path}`, lastModified: new Date() }));
+
+  const dynamicRoutes: MetadataRoute.Sitemap = [
+    ...posts.data.map((post) => ({
+      url: `${SITE_URL}/tin-tuc/${post.slug}`,
+      lastModified: post.publishedAt ? new Date(post.publishedAt) : new Date(),
+    })),
+    ...events.data.map((event) => ({
+      url: `${SITE_URL}/su-kien/${event.slug}`,
+      lastModified: event.startDate ? new Date(event.startDate) : new Date(),
+    })),
+    ...teachers.data.map((teacher) => ({
+      url: `${SITE_URL}/doi-ngu/${teacher.slug}`,
+      lastModified: new Date(),
+    })),
+    ...achievements.data.map((achievement) => ({
+      url: `${SITE_URL}/thanh-tich/${achievement.slug}`,
+      lastModified: achievement.year ? new Date(`${achievement.year}-01-01`) : new Date(),
+    })),
+    ...albums.data.map((album) => ({
+      url: `${SITE_URL}/cuoc-song-hoc-duong/${album.slug}`,
+      lastModified: new Date(),
+    })),
+  ];
+
+  return [...staticRoutes, ...dynamicRoutes];
+}

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { BreadcrumbItem } from '@/lib/types';
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumbs({ items }: BreadcrumbsProps) {
+  if (!items?.length) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm text-slate-600">
+      <ol className="flex flex-wrap items-center gap-2">
+        {items.map((item, index) => (
+          <li key={item.href} className="flex items-center gap-2">
+            {index > 0 && <span className="text-slate-400">/</span>}
+            {index === items.length - 1 ? (
+              <span className="font-medium text-slate-900">{item.label}</span>
+            ) : (
+              <Link className="hover:text-primary-600" href={item.href}>
+                {item.label}
+              </Link>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import clsx from 'clsx';
+import { getMediaAlt, getMediaUrl } from '@/lib/image';
+import { Media } from '@/lib/types';
+
+type CardProps = {
+  href: string;
+  title: string;
+  description?: string | null;
+  media?: Media | null;
+  meta?: string | null;
+  className?: string;
+};
+
+export default function Card({ href, title, description, media, meta, className }: CardProps) {
+  const imageUrl = getMediaUrl(media);
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'group flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg',
+        className,
+      )}
+    >
+      {imageUrl && (
+        <div className="relative aspect-[16/9] w-full overflow-hidden">
+          <Image
+            src={imageUrl}
+            alt={getMediaAlt(media, title)}
+            fill
+            className="object-cover transition duration-500 group-hover:scale-105"
+            sizes="(min-width: 1024px) 400px, 100vw"
+          />
+        </div>
+      )}
+      <div className="flex flex-1 flex-col gap-3 p-6">
+        {meta && <span className="text-xs font-semibold uppercase tracking-wide text-primary-600">{meta}</span>}
+        <h3 className="text-lg font-semibold text-slate-900 group-hover:text-primary-600">{title}</h3>
+        {description && <p className="text-sm text-slate-600">{description}</p>}
+        <div className="mt-auto pt-4 text-sm font-semibold text-primary-600">Đọc thêm →</div>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/components/EventsList.tsx
+++ b/frontend/src/components/EventsList.tsx
@@ -1,0 +1,43 @@
+import Card from './Card';
+import type { Event } from '@/lib/types';
+import { formatDateRange } from '@/lib/utils';
+
+type EventsListProps = {
+  events: Event[];
+};
+
+export default function EventsList({ events }: EventsListProps) {
+  if (!events?.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 p-12 text-center text-slate-500">
+        Hiện chưa có sự kiện sắp diễn ra.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Sự kiện</p>
+          <h2 className="text-2xl font-bold text-slate-900">Kết nối cộng đồng Xuân Cao</h2>
+        </div>
+        <a className="text-sm font-semibold text-primary-600" href="/su-kien">
+          Xem tất cả →
+        </a>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        {events.map((event) => (
+          <Card
+            key={event.id}
+            href={`/su-kien/${event.slug}`}
+            title={event.title}
+            description={event.description}
+            media={event.coverImage}
+            meta={formatDateRange(event.startDate, event.endDate)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Gallery.tsx
+++ b/frontend/src/components/Gallery.tsx
@@ -1,0 +1,60 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { Album } from '@/lib/types';
+import { getMediaAlt, getMediaUrl } from '@/lib/image';
+
+type GalleryProps = {
+  items: Album[];
+};
+
+export default function Gallery({ items }: GalleryProps) {
+  if (!items?.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 p-12 text-center text-slate-500">
+        Bộ sưu tập hình ảnh đang được cập nhật.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Đời sống học đường</p>
+          <h2 className="text-2xl font-bold text-slate-900">Khoảnh khắc Xuân Cao</h2>
+        </div>
+        <a className="text-sm font-semibold text-primary-600" href="/cuoc-song-hoc-duong">
+          Xem tất cả →
+        </a>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        {items.map((album) => {
+          const firstMedia = album.media?.[0];
+          const imageUrl = getMediaUrl(firstMedia);
+          return (
+            <Link
+              key={album.id}
+              href={album.slug ? `/cuoc-song-hoc-duong/${album.slug}` : '/cuoc-song-hoc-duong'}
+              className="group relative flex h-64 items-end overflow-hidden rounded-3xl bg-slate-200 p-6 text-white shadow-lg"
+            >
+              {imageUrl && (
+                <Image
+                  src={imageUrl}
+                  alt={getMediaAlt(firstMedia, album.title)}
+                  fill
+                  className="object-cover transition duration-500 group-hover:scale-110"
+                  sizes="(min-width: 1024px) 400px, 100vw"
+                />
+              )}
+              <div className="relative z-10">
+                <p className="text-lg font-semibold">{album.title}</p>
+                {album.description && <p className="text-sm opacity-80">{album.description}</p>}
+              </div>
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { HeroBlock } from '@/lib/types';
+import { getMediaUrl, getMediaAlt } from '@/lib/image';
+
+type HeroProps = {
+  data: HeroBlock;
+};
+
+export default function Hero({ data }: HeroProps) {
+  const mediaUrl = getMediaUrl(data.media);
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-primary-50 via-white to-white">
+      <div className="container grid gap-10 py-16 md:grid-cols-2 md:items-center lg:py-24">
+        <div className="space-y-6">
+          <span className="inline-flex items-center rounded-full bg-primary-100 px-3 py-1 text-xs font-semibold text-primary-700">
+            Ngôi trường hạnh phúc
+          </span>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+            {data.headline}
+          </h1>
+          {data.subheadline && <p className="text-lg text-slate-600">{data.subheadline}</p>}
+          <div className="flex flex-wrap gap-4">
+            {data.primaryCta && (
+              <Link
+                href={data.primaryCta.url}
+                className="rounded-full bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-primary-600/40 transition hover:bg-primary-700"
+              >
+                {data.primaryCta.label}
+              </Link>
+            )}
+            {data.secondaryCta && (
+              <Link
+                href={data.secondaryCta.url}
+                className="rounded-full border border-primary-600 px-6 py-3 text-sm font-semibold text-primary-600 transition hover:bg-primary-50"
+              >
+                {data.secondaryCta.label}
+              </Link>
+            )}
+          </div>
+        </div>
+        <div className="relative">
+          {mediaUrl ? (
+            <Image
+              src={mediaUrl}
+              alt={getMediaAlt(data.media, data.headline)}
+              width={640}
+              height={640}
+              className="w-full rounded-3xl object-cover shadow-xl"
+              priority
+            />
+          ) : (
+            <div className="flex h-full min-h-[320px] items-center justify-center rounded-3xl bg-primary-100 text-primary-700">
+              <p className="text-lg font-semibold">Hình ảnh Trường THCS Xuân Cao</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/NewsGrid.tsx
+++ b/frontend/src/components/NewsGrid.tsx
@@ -1,0 +1,43 @@
+import Card from './Card';
+import type { Post } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+type NewsGridProps = {
+  posts: Post[];
+};
+
+export default function NewsGrid({ posts }: NewsGridProps) {
+  if (!posts?.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 p-12 text-center text-slate-500">
+        Chưa có bài viết nào được xuất bản.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Tin tức</p>
+          <h2 className="text-2xl font-bold text-slate-900">Nhịp sống Xuân Cao</h2>
+        </div>
+        <a className="text-sm font-semibold text-primary-600" href="/tin-tuc">
+          Xem tất cả →
+        </a>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {posts.map((post) => (
+          <Card
+            key={post.id}
+            href={`/tin-tuc/${post.slug}`}
+            title={post.title}
+            description={post.excerpt}
+            media={post.coverImage}
+            meta={post.publishedAt ? formatDate(post.publishedAt) : undefined}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,26 @@
+import Breadcrumbs from './Breadcrumbs';
+import { BreadcrumbItem } from '@/lib/types';
+
+interface PageHeaderProps {
+  title: string;
+  description?: string | null;
+  breadcrumbs?: BreadcrumbItem[];
+  actions?: React.ReactNode;
+}
+
+export default function PageHeader({ title, description, breadcrumbs, actions }: PageHeaderProps) {
+  return (
+    <section className="border-b border-slate-200 bg-gradient-to-b from-white to-slate-50/80">
+      <div className="container flex flex-col gap-6 py-12">
+        {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
+        <div className="flex flex-wrap items-end justify-between gap-6">
+          <div className="space-y-3">
+            <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">{title}</h1>
+            {description && <p className="text-base text-slate-600 sm:text-lg">{description}</p>}
+          </div>
+          {actions}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/RichText.tsx
+++ b/frontend/src/components/RichText.tsx
@@ -1,0 +1,13 @@
+interface RichTextProps {
+  html?: string | null;
+}
+
+export default function RichText({ html }: RichTextProps) {
+  if (!html) return null;
+  return (
+    <div
+      className="richtext space-y-4 text-base leading-relaxed text-slate-700 [&_h2]:mt-8 [&_h2]:text-2xl [&_h2]:font-semibold [&_h3]:mt-6 [&_h3]:text-xl [&_a]:text-primary-600 [&_a:hover]:text-primary-700"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/frontend/src/components/Testimonials.tsx
+++ b/frontend/src/components/Testimonials.tsx
@@ -1,0 +1,43 @@
+import type { Testimonial } from '@/lib/types';
+
+interface TestimonialsProps {
+  testimonials: Testimonial[];
+}
+
+export default function Testimonials({ testimonials }: TestimonialsProps) {
+  if (!testimonials?.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-primary-200 bg-white p-12 text-center text-slate-500">
+        Góc nhìn từ phụ huynh và học sinh đang được cập nhật.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Góc nhìn</p>
+          <h2 className="text-2xl font-bold text-slate-900">Chia sẻ từ cộng đồng</h2>
+        </div>
+        <a className="text-sm font-semibold text-primary-600" href="/goc-nhin">
+          Xem tất cả →
+        </a>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        {testimonials.map((testimonial) => (
+          <article
+            key={testimonial.id}
+            className="h-full rounded-3xl border border-white bg-white p-8 shadow-lg shadow-primary-200/40"
+          >
+            <p className="text-lg font-medium text-slate-900">“{testimonial.quote}”</p>
+            <div className="mt-6">
+              <p className="text-sm font-semibold text-primary-700">{testimonial.name}</p>
+              {testimonial.role && <p className="text-sm text-slate-500">{testimonial.role}</p>}
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/forms/ContactForm.tsx
+++ b/frontend/src/components/forms/ContactForm.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, type FormEventHandler } from 'react';
+
+type ContactFormProps = {
+  endpoint?: string | null;
+};
+
+export default function ContactForm({ endpoint }: ContactFormProps) {
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    setStatus('submitting');
+    try {
+      if (endpoint) {
+        await fetch(endpoint, {
+          method: 'POST',
+          body: formData,
+        });
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 800));
+      }
+      setStatus('success');
+      event.currentTarget.reset();
+    } catch (error) {
+      console.error(error);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-slate-200 p-8 shadow-sm">
+      <div className="grid gap-6 sm:grid-cols-2">
+        <label className="flex flex-col gap-2 text-sm text-slate-700">
+          Họ và tên
+          <input
+            name="name"
+            required
+            className="rounded-xl border border-slate-300 px-4 py-3 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-700">
+          Email
+          <input
+            type="email"
+            name="email"
+            required
+            className="rounded-xl border border-slate-300 px-4 py-3 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-700">
+          Số điện thoại
+          <input
+            type="tel"
+            name="phone"
+            className="rounded-xl border border-slate-300 px-4 py-3 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-700">
+          Thời gian mong muốn tham quan
+          <input
+            type="date"
+            name="visitDate"
+            className="rounded-xl border border-slate-300 px-4 py-3 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+          />
+        </label>
+      </div>
+      <label className="flex flex-col gap-2 text-sm text-slate-700">
+        Lời nhắn
+        <textarea
+          name="message"
+          rows={4}
+          className="rounded-xl border border-slate-300 px-4 py-3 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="inline-flex items-center justify-center rounded-full bg-primary-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary-700 disabled:opacity-60"
+      >
+        {status === 'submitting' ? 'Đang gửi...' : 'Đăng ký tham quan'}
+      </button>
+      {status === 'success' && (
+        <p className="text-sm text-green-600">Cảm ơn bạn! Chúng tôi sẽ liên hệ trong thời gian sớm nhất.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-sm text-red-600">Có lỗi xảy ra. Vui lòng thử lại sau.</p>
+      )}
+    </form>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,344 @@
+import 'server-only';
+
+import type {
+  Album,
+  Event,
+  HomePageData,
+  PaginatedResponse,
+  Post,
+  Teacher,
+  Testimonial,
+  Achievement,
+  Announcement,
+  AboutPage,
+  ContactPage,
+  OrganizationProfile,
+} from './types';
+
+const STRAPI_API_URL = process.env.STRAPI_API_URL;
+const STRAPI_API_TOKEN = process.env.STRAPI_API_TOKEN;
+
+async function fetchFromStrapi<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  const normalized = endpoint.startsWith('/api')
+    ? endpoint
+    : `/api${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
+  if (!STRAPI_API_URL) {
+    return fallbackData(normalized) as T;
+  }
+
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    ...options.headers,
+  };
+
+  if (STRAPI_API_TOKEN) {
+    headers.Authorization = `Bearer ${STRAPI_API_TOKEN}`;
+  }
+
+  const res = await fetch(`${STRAPI_API_URL}${normalized}`, {
+    ...options,
+    headers,
+    next: { revalidate: 3600 },
+  });
+
+  if (!res.ok) {
+    console.error(`Strapi request failed: ${res.status} ${res.statusText}`);
+    return fallbackData(normalized) as T;
+  }
+
+  return res.json();
+}
+
+function fallbackData(endpoint: string): unknown {
+  switch (true) {
+    case endpoint.includes('/homepage'):
+      return {
+        hero: {
+          headline: 'Khơi nguồn tri thức, nuôi dưỡng tương lai',
+          subheadline:
+            'Trường THCS Xuân Cao đồng hành cùng học sinh trên hành trình khám phá và phát triển toàn diện.',
+          primaryCta: { label: 'Tìm hiểu thêm', url: '/gioi-thieu' },
+          secondaryCta: { label: 'Đăng ký tham quan', url: '/lien-he' },
+        },
+        news: samplePosts,
+        events: sampleEvents,
+        schoolLife: sampleAlbums,
+        testimonials: sampleTestimonials,
+      } satisfies HomePageData;
+    case endpoint.includes('/posts'):
+      return {
+        data: samplePosts,
+        pagination: {
+          page: 1,
+          pageSize: samplePosts.length,
+          pageCount: 1,
+          total: samplePosts.length,
+        },
+      } satisfies PaginatedResponse<Post>;
+    case endpoint.includes('/events'):
+      return {
+        data: sampleEvents,
+        pagination: {
+          page: 1,
+          pageSize: sampleEvents.length,
+          pageCount: 1,
+          total: sampleEvents.length,
+        },
+      } satisfies PaginatedResponse<Event>;
+    case endpoint.includes('/teachers'):
+      return {
+        data: sampleTeachers,
+        pagination: {
+          page: 1,
+          pageSize: sampleTeachers.length,
+          pageCount: 1,
+          total: sampleTeachers.length,
+        },
+      } satisfies PaginatedResponse<Teacher>;
+    case endpoint.includes('/achievements'):
+      return {
+        data: sampleAchievements,
+        pagination: {
+          page: 1,
+          pageSize: sampleAchievements.length,
+          pageCount: 1,
+          total: sampleAchievements.length,
+        },
+      } satisfies PaginatedResponse<Achievement>;
+    case endpoint.includes('/testimonials'):
+      return {
+        data: sampleTestimonials,
+        pagination: {
+          page: 1,
+          pageSize: sampleTestimonials.length,
+          pageCount: 1,
+          total: sampleTestimonials.length,
+        },
+      } satisfies PaginatedResponse<Testimonial>;
+    case endpoint.includes('/albums'):
+      return {
+        data: sampleAlbums,
+        pagination: {
+          page: 1,
+          pageSize: sampleAlbums.length,
+          pageCount: 1,
+          total: sampleAlbums.length,
+        },
+      } satisfies PaginatedResponse<Album>;
+    case endpoint.includes('/about'):
+      return sampleAbout;
+    case endpoint.includes('/contact'):
+      return sampleContact;
+    case endpoint.includes('/organization'):
+      return sampleOrganization;
+    default:
+      return { data: [] };
+  }
+}
+
+const samplePosts: Post[] = [
+  {
+    id: 1,
+    title: 'Lễ khai giảng năm học 2024-2025',
+    slug: 'le-khai-giang-2024-2025',
+    excerpt: 'Không khí rộn ràng của lễ khai giảng tại Trường THCS Xuân Cao.',
+    publishedAt: '2024-09-05T08:00:00.000Z',
+  },
+  {
+    id: 2,
+    title: 'Học sinh Xuân Cao đạt giải Nhất Toán học cấp tỉnh',
+    slug: 'hoc-sinh-dat-giai-nhat-toan-cap-tinh',
+    excerpt: 'Thành tích nổi bật của em Nguyễn Minh Anh trong kỳ thi HSG Toán.',
+    publishedAt: '2024-04-12T08:00:00.000Z',
+  },
+  {
+    id: 3,
+    title: 'Chuỗi hoạt động trải nghiệm STEM 2024',
+    slug: 'chuoi-hoat-dong-trai-nghiem-stem-2024',
+    excerpt: 'Học sinh hào hứng tham gia các dự án STEM sáng tạo.',
+    publishedAt: '2024-03-21T08:00:00.000Z',
+  },
+];
+
+const sampleEvents: Event[] = [
+  {
+    id: 1,
+    title: 'Ngày hội Khoa học Sáng tạo',
+    slug: 'ngay-hoi-khoa-hoc-sang-tao',
+    description:
+      'Ngày hội trình diễn các dự án khoa học của học sinh toàn trường, kết nối phụ huynh và cộng đồng.',
+    startDate: '2024-11-10T01:00:00.000Z',
+    endDate: '2024-11-10T08:00:00.000Z',
+    location: 'Khuôn viên trường THCS Xuân Cao',
+  },
+  {
+    id: 2,
+    title: 'Hội thảo định hướng nghề nghiệp',
+    slug: 'hoi-thao-dinh-huong-nghe-nghiep',
+    description:
+      'Chuyên gia chia sẻ về kỹ năng tương lai và lựa chọn định hướng học tập cho học sinh lớp 9.',
+    startDate: '2024-10-02T02:00:00.000Z',
+    location: 'Phòng đa năng, Trường THCS Xuân Cao',
+  },
+];
+
+const sampleAlbums: Album[] = [
+  {
+    id: 1,
+    title: 'Khoảnh khắc Xuân Cao',
+    slug: 'khoanh-khac-xuan-cao',
+    description: 'Những hình ảnh đời sống học đường rực rỡ sắc màu.',
+    media: [],
+  },
+];
+
+const sampleTestimonials: Testimonial[] = [
+  {
+    id: 1,
+    name: 'Nguyễn Thu Hà',
+    role: 'Phụ huynh học sinh lớp 8A1',
+    quote:
+      'Xuân Cao là môi trường học tập hiện đại, tận tâm giúp con tôi phát huy năng lực và tự tin.',
+  },
+];
+
+const sampleTeachers: Teacher[] = [
+  {
+    id: 1,
+    name: 'Thầy Trần Minh Quang',
+    slug: 'tran-minh-quang',
+    position: 'Hiệu trưởng',
+    bio: 'Hơn 15 năm kinh nghiệm quản lý giáo dục với định hướng đổi mới sáng tạo.',
+  },
+];
+
+const sampleAchievements: Achievement[] = [
+  {
+    id: 1,
+    title: 'Giải Nhất Toán học cấp Tỉnh 2024',
+    slug: 'giai-nhat-toan-cap-tinh-2024',
+    year: 2024,
+    level: 'Tỉnh',
+    description: 'Học sinh Nguyễn Minh Anh đạt giải Nhất cuộc thi HSG Toán.',
+  },
+];
+
+const sampleAbout: AboutPage = {
+  title: 'Về Trường THCS Xuân Cao',
+  mission:
+    '<p>Sứ mệnh của chúng tôi là nuôi dưỡng thế hệ học sinh tự tin, sáng tạo và có trách nhiệm với cộng đồng.</p>',
+  vision:
+    '<p>Trở thành trường THCS dẫn đầu về đổi mới giáo dục, lấy học sinh làm trung tâm.</p>',
+  history:
+    '<p>Được thành lập từ năm 2005, Xuân Cao không ngừng phát triển, đầu tư cơ sở vật chất và nâng cao chất lượng giảng dạy.</p>',
+  stats: [
+    { id: 1, label: 'Học sinh đang theo học', value: '1.200+' },
+    { id: 2, label: 'Giáo viên giàu kinh nghiệm', value: '80+' },
+    { id: 3, label: 'Giải thưởng cấp tỉnh và quốc gia', value: '150+' },
+  ],
+};
+
+const sampleContact: ContactPage = {
+  title: 'Liên hệ',
+  description: 'Hãy kết nối với chúng tôi để được tư vấn và hỗ trợ chi tiết.',
+  address: 'Số 1 Xuân Cao, Thanh Hóa',
+  email: 'info@thcs-abc.edu.vn',
+  phone: '(024) 1234 5678',
+  mapEmbed:
+    '<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3919.502!2d106.700!3d10.776!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0:0x0!2zMTDCsDQ2JzMzLjgiTiAxMDbCsDQyJzAwLjAiRQ!5e0!3m2!1sen!2s!4v1616400000000" width="100%" height="360" style="border:0;" allowFullScreen loading="lazy"></iframe>',
+};
+
+const sampleOrganization: OrganizationProfile = {
+  legalName: 'Trường Trung học Cơ sở Xuân Cao',
+  foundingDate: '2005-09-01',
+  sameAs: ['https://facebook.com', 'https://youtube.com'],
+};
+
+export async function fetchHomePage(): Promise<HomePageData> {
+  return fetchFromStrapi<HomePageData>('/homepage?populate=deep');
+}
+
+export async function fetchPosts(page = 1, pageSize = 12): Promise<PaginatedResponse<Post>> {
+  return fetchFromStrapi<PaginatedResponse<Post>>(
+    `/posts?populate=deep&pagination[page]=${page}&pagination[pageSize]=${pageSize}`,
+  );
+}
+
+export async function fetchPostBySlug(slug: string): Promise<Post | null> {
+  const res = await fetchFromStrapi<PaginatedResponse<Post>>(
+    `/posts?filters[slug][$eq]=${slug}&populate=deep`,
+  );
+  return res.data?.[0] ?? null;
+}
+
+export async function fetchEvents(page = 1, pageSize = 12): Promise<PaginatedResponse<Event>> {
+  return fetchFromStrapi<PaginatedResponse<Event>>(
+    `/events?populate=deep&sort=startDate:asc&pagination[page]=${page}&pagination[pageSize]=${pageSize}`,
+  );
+}
+
+export async function fetchEventBySlug(slug: string): Promise<Event | null> {
+  const res = await fetchFromStrapi<PaginatedResponse<Event>>(
+    `/events?filters[slug][$eq]=${slug}&populate=deep`,
+  );
+  return res.data?.[0] ?? null;
+}
+
+export async function fetchTeachers(): Promise<PaginatedResponse<Teacher>> {
+  return fetchFromStrapi<PaginatedResponse<Teacher>>('/teachers?populate=deep');
+}
+
+export async function fetchTeacherBySlug(slug: string): Promise<Teacher | null> {
+  const res = await fetchFromStrapi<PaginatedResponse<Teacher>>(
+    `/teachers?filters[slug][$eq]=${slug}&populate=deep`,
+  );
+  return res.data?.[0] ?? null;
+}
+
+export async function fetchAchievements(): Promise<PaginatedResponse<Achievement>> {
+  return fetchFromStrapi<PaginatedResponse<Achievement>>('/achievements?populate=deep');
+}
+
+export async function fetchAchievementBySlug(slug: string): Promise<Achievement | null> {
+  const res = await fetchFromStrapi<PaginatedResponse<Achievement>>(
+    `/achievements?filters[slug][$eq]=${slug}&populate=deep`,
+  );
+  return res.data?.[0] ?? null;
+}
+
+export async function fetchTestimonials(): Promise<Testimonial[]> {
+  const res = await fetchFromStrapi<PaginatedResponse<Testimonial>>(
+    `/testimonials?filters[featured][$eq]=true&populate=deep`,
+  );
+  return res.data ?? [];
+}
+
+export async function fetchAlbums(): Promise<PaginatedResponse<Album>> {
+  return fetchFromStrapi<PaginatedResponse<Album>>('/albums?populate=deep');
+}
+
+export async function fetchAlbumBySlug(slug: string) {
+  const res = await fetchFromStrapi<PaginatedResponse<Album>>(
+    `/albums?filters[slug][$eq]=${slug}&populate=deep`,
+  );
+  return res.data?.[0] ?? null;
+}
+
+export async function fetchAnnouncements(): Promise<PaginatedResponse<Announcement>> {
+  const nowIso = new Date().toISOString();
+  return fetchFromStrapi<PaginatedResponse<Announcement>>(
+    `/announcements?filters[endDate][$gt]=${nowIso}&sort=pinned:desc,startDate:desc`,
+  );
+}
+
+export async function fetchAboutPage(): Promise<AboutPage> {
+  return fetchFromStrapi<AboutPage>('/about?populate=deep');
+}
+
+export async function fetchContactPage(): Promise<ContactPage> {
+  return fetchFromStrapi<ContactPage>('/contact?populate=deep');
+}
+
+export async function fetchOrganizationProfile(): Promise<OrganizationProfile> {
+  return fetchFromStrapi<OrganizationProfile>('/organization?populate=deep');
+}

--- a/frontend/src/lib/image.ts
+++ b/frontend/src/lib/image.ts
@@ -1,0 +1,13 @@
+import { Media } from './types';
+
+export function getMediaUrl(media?: Media | null) {
+  if (!media) return undefined;
+  const baseUrl = process.env.NEXT_PUBLIC_CDN_URL ?? process.env.STRAPI_API_URL ?? '';
+  if (media.url.startsWith('http')) return media.url;
+  return `${baseUrl}${media.url}`;
+}
+
+export function getMediaAlt(media?: Media | null, fallback?: string) {
+  if (!media) return fallback ?? '';
+  return media.alternativeText ?? fallback ?? '';
+}

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,0 +1,125 @@
+import type { Metadata } from 'next';
+import { Post, Event, Seo, HomePageData, BreadcrumbItem } from './types';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://thcs-abc.edu.vn';
+
+export function buildSeoMetadata(
+  seo: Seo | null | undefined,
+  defaults: Partial<Metadata> = {},
+): Metadata {
+  const metaTitle = seo?.metaTitle ?? (defaults.title as string | undefined);
+  const metaDescription = seo?.metaDescription ??
+    (typeof defaults.description === 'string' ? defaults.description : undefined);
+
+  const images = seo?.ogImage?.url
+    ? [{ url: absoluteUrl(seo.ogImage.url), alt: seo.ogImage.alternativeText ?? metaTitle }]
+    : undefined;
+
+  return {
+    title: metaTitle,
+    description: metaDescription,
+    alternates: {
+      canonical: seo?.canonicalURL ?? defaults.alternates?.canonical ?? SITE_URL,
+    },
+    openGraph: {
+      type: 'website',
+      title: metaTitle,
+      description: metaDescription,
+      url: seo?.canonicalURL ?? defaults?.openGraph?.url ?? SITE_URL,
+      images,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: metaTitle ?? undefined,
+      description: metaDescription ?? undefined,
+      images,
+    },
+  } satisfies Metadata;
+}
+
+export function buildArticleMetadata(post: Post): Metadata {
+  return {
+    ...buildSeoMetadata(post.seo, {
+      title: post.title,
+      description: post.excerpt ?? undefined,
+      openGraph: {
+        type: 'article',
+        url: `${SITE_URL}/tin-tuc/${post.slug}`,
+      },
+    }),
+    other: {
+      'script:type': 'application/ld+json',
+    },
+  } satisfies Metadata;
+}
+
+export function buildEventMetadata(event: Event): Metadata {
+  return buildSeoMetadata(event.seo, {
+    title: event.title,
+    description: event.description ?? undefined,
+    openGraph: {
+      type: 'event',
+      url: `${SITE_URL}/su-kien/${event.slug}`,
+    },
+  });
+}
+
+export function buildHomeMetadata(home: HomePageData): Metadata {
+  return buildSeoMetadata(home.seo, {
+    title: 'Trường THCS Xuân Cao',
+    description: 'Website chính thức của Trường THCS Xuân Cao.',
+  });
+}
+
+export function buildBreadcrumbJsonLd(items: BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      item: absoluteUrl(item.href),
+    })),
+  };
+}
+
+export function buildArticleJsonLd(post: Post) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'NewsArticle',
+    headline: post.title,
+    datePublished: post.publishedAt,
+    dateModified: post.publishedAt,
+    image: post.coverImage?.url ? [absoluteUrl(post.coverImage.url)] : undefined,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${SITE_URL}/tin-tuc/${post.slug}`,
+    },
+  };
+}
+
+export function buildEventJsonLd(event: Event) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event.title,
+    startDate: event.startDate,
+    endDate: event.endDate ?? undefined,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: {
+      '@type': 'Place',
+      name: event.location ?? 'Trường THCS Xuân Cao',
+      address: event.location ?? 'Trường THCS Xuân Cao',
+    },
+    image: event.coverImage?.url ? [absoluteUrl(event.coverImage.url)] : undefined,
+    description: event.description ?? undefined,
+  };
+}
+
+export function absoluteUrl(path: string) {
+  if (!path) return SITE_URL;
+  if (path.startsWith('http')) return path;
+  return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,168 @@
+export type MediaFormat = {
+  url: string;
+  alternativeText?: string | null;
+  width?: number | null;
+  height?: number | null;
+};
+
+export type Media = {
+  id: number | string;
+  url: string;
+  alternativeText?: string | null;
+  formats?: Record<string, MediaFormat>;
+};
+
+export type Seo = {
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  ogImage?: Media | null;
+  canonicalURL?: string | null;
+};
+
+export type HeroBlock = {
+  headline: string;
+  subheadline?: string | null;
+  media?: Media | null;
+  primaryCta?: CTA | null;
+  secondaryCta?: CTA | null;
+};
+
+export type CTA = {
+  label: string;
+  url: string;
+};
+
+export type Post = {
+  id: number | string;
+  title: string;
+  slug: string;
+  excerpt?: string | null;
+  content?: string | null;
+  coverImage?: Media | null;
+  gallery?: Media[];
+  publishedAt?: string | null;
+  seo?: Seo | null;
+};
+
+export type Event = {
+  id: number | string;
+  title: string;
+  slug: string;
+  description?: string | null;
+  startDate: string;
+  endDate?: string | null;
+  location?: string | null;
+  coverImage?: Media | null;
+  gallery?: Media[];
+  rsvpLink?: string | null;
+  seo?: Seo | null;
+};
+
+export type Teacher = {
+  id: number | string;
+  name: string;
+  slug: string;
+  position?: string | null;
+  bio?: string | null;
+  photo?: Media | null;
+  achievements?: Achievement[];
+  seo?: Seo | null;
+};
+
+export type Achievement = {
+  id: number | string;
+  title: string;
+  slug: string;
+  year?: number | null;
+  level?: string | null;
+  description?: string | null;
+  images?: Media[];
+  seo?: Seo | null;
+};
+
+export type Testimonial = {
+  id: number | string;
+  name: string;
+  role?: string | null;
+  quote: string;
+  avatar?: Media | null;
+  featured?: boolean;
+};
+
+export type Album = {
+  id: number | string;
+  title: string;
+  slug: string;
+  description?: string | null;
+  media: Media[];
+  seo?: Seo | null;
+};
+
+export type Announcement = {
+  id: number | string;
+  title: string;
+  slug: string;
+  content: string;
+  pinned?: boolean;
+  startDate?: string | null;
+  endDate?: string | null;
+  seo?: Seo | null;
+};
+
+export type HomePageData = {
+  hero: HeroBlock;
+  news: Post[];
+  events: Event[];
+  schoolLife: Album[];
+  testimonials: Testimonial[];
+  seo?: Seo | null;
+};
+
+export type AboutPage = {
+  title: string;
+  mission?: string | null;
+  vision?: string | null;
+  history?: string | null;
+  stats?: StatItem[];
+  seo?: Seo | null;
+};
+
+export type StatItem = {
+  id: number | string;
+  label: string;
+  value: string;
+};
+
+export type ContactPage = {
+  title: string;
+  description?: string | null;
+  address?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  mapEmbed?: string | null;
+  formEndpoint?: string | null;
+  seo?: Seo | null;
+};
+
+export type OrganizationProfile = {
+  legalName: string;
+  logo?: Media | null;
+  foundingDate?: string | null;
+  sameAs?: string[];
+  seo?: Seo | null;
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    pageCount: number;
+    total: number;
+  };
+};
+
+export type BreadcrumbItem = {
+  label: string;
+  href: string;
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,26 @@
+export function formatDate(date: string | Date) {
+  const dt = typeof date === 'string' ? new Date(date) : date;
+  return dt.toLocaleDateString('vi-VN', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+export function formatDateRange(start: string, end?: string | null) {
+  const startDt = new Date(start);
+  if (!end) {
+    return formatDate(startDt);
+  }
+  const endDt = new Date(end);
+  if (startDt.toDateString() === endDt.toDateString()) {
+    return `${formatDate(startDt)} · ${startDt.toLocaleTimeString('vi-VN', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })} - ${endDt.toLocaleTimeString('vi-VN', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })}`;
+  }
+  return `${formatDate(startDt)} - ${formatDate(endDt)}`;
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply min-h-screen bg-white text-slate-900 antialiased;
+}
+
+a {
+  @apply text-primary-600 hover:text-primary-700 transition-colors;
+}
+
+.container {
+  @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#f0f6ff',
+          100: '#dbe9ff',
+          200: '#bcd6ff',
+          300: '#8db9ff',
+          400: '#5e99ff',
+          500: '#2f76ff',
+          600: '#1557e6',
+          700: '#0e43b4',
+          800: '#0b3390',
+          900: '#09296f'
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src/**/*", "next.config.mjs", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 frontend with App Router, shared components, SEO helpers, and mocked Strapi-backed data
- define Strapi v5 content model, plugins, and configuration for posts, events, teachers, achievements, testimonials, albums, and organization single types
- document environment variables and setup steps for both frontend and CMS along with Git ignores

## Testing
- not run (Node dependencies cannot be installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d5628ed26c832eabb777abd54063ab